### PR TITLE
Day 3: Capacity handling, floor queues, and observer-driven boarding

### DIFF
--- a/src/ElevatorSim.Domain/Building.cs
+++ b/src/ElevatorSim.Domain/Building.cs
@@ -1,13 +1,22 @@
-﻿namespace ElevatorSim.Domain;
+﻿using System;
+using System.Collections.Generic;
 
-public sealed class Building
+namespace ElevatorSim.Domain;
+
+public sealed class Building : IElevatorObserver
 {
     private readonly List<IElevator> _elevators = new();
-    private readonly Dictionary<int, Queue<Request>> _floorQueues = new();
+    // Legacy request queues kept for compatibility/visibility
+    private readonly Dictionary<int, Queue<Request>> _floorRequestQueues = new();
+
+    // Day 3: per-floor passenger queues (by direction)
+    private readonly Dictionary<int, FloorQueue> _passengerQueues = new();
+
+    // Optional: simple event buffer for console to print after ticks
+    private readonly List<string> _events = new();
 
     public int Floors { get; }
     public IReadOnlyList<IElevator> Elevators => _elevators.AsReadOnly();
-
     public IDispatchStrategy DispatchStrategy { get; }
 
     public Building(int floors, IDispatchStrategy dispatchStrategy)
@@ -18,34 +27,52 @@ public sealed class Building
 
         for (int f = 0; f < Floors; f++)
         {
-            _floorQueues[f] = new Queue<Request>();
+            _floorRequestQueues[f] = new Queue<Request>();
         }
     }
 
     public void AddElevator(IElevator elevator)
     {
-        _elevators.Add(elevator ?? throw new ArgumentNullException(nameof(elevator)));
+        var e = elevator ?? throw new ArgumentNullException(nameof(elevator));
+        _elevators.Add(e);
+        e.Observer = this;
     }
 
+    // Existing API: submit a floor call (direction + count)
     public void SubmitCall(Request req)
     {
         ValidateFloor(req.Floor);
-        var chosen = DispatchStrategy.ChooseElevator(this, req);
 
+        // Day 3: create passenger placeholders in per-floor queues
+        var fq = GetPassengerQueue(req.Floor);
+        for (int i = 0; i < req.Count; i++)
+        {
+            // Simple destination heuristic for Day 3:
+            // Up calls go a few floors up (min +1), down calls go a few floors down (max -1)
+            int dest = req.Direction == Direction.Up
+                ? Math.Min(Floors - 1, Math.Max(req.Floor + 1, req.Floor + 3))
+                : Math.Max(0, Math.Min(req.Floor - 1, req.Floor - 3));
+
+            fq.Enqueue(req.Direction, new Passenger(req.Floor, dest));
+        }
+
+        // Try immediate dispatch via strategy
+        var chosen = DispatchStrategy.ChooseElevator(this, req);
         if (chosen != null && chosen.CanAccept(req))
         {
             chosen.Assign(req);
         }
         else
         {
-            _floorQueues[req.Floor].Enqueue(req);
+            // Preserve the legacy request queue for informational purposes
+            _floorRequestQueues[req.Floor].Enqueue(req);
         }
     }
 
     public IReadOnlyCollection<Request> PeekQueueAt(int floor)
     {
         ValidateFloor(floor);
-        return _floorQueues[floor].ToArray();
+        return _floorRequestQueues[floor].ToArray();
     }
 
     public void TickAll()
@@ -53,12 +80,134 @@ public sealed class Building
         foreach (var e in _elevators)
             e.Tick();
 
-        // Future: attempt to dispatch queued requests again after ticks
+        // After all elevators tick, attempt to dispatch waiting floors
+        TryDispatchQueues();
+    }
+
+    // Optional: used by console to print arrival/load events after each tick
+    public IReadOnlyList<string> DrainEvents()
+    {
+        if (_events.Count == 0) return Array.Empty<string>();
+        var copy = _events.ToArray();
+        _events.Clear();
+        return copy;
+    }
+
+    // IElevatorObserver implementation
+
+    public void OnArrivedAtFloor(IElevator elevator, int floor)
+    {
+        _events.Add($"Arrived: {elevator.Id} at F:{floor}");
+    }
+
+    public void OnDoorsOpened(IElevator elevator, int floor)
+    {
+        // 1) Unload passengers whose destination == floor
+        int unloaded = elevator.UnloadAtCurrentFloor();
+
+        // 2) Load waiting passengers up to available capacity
+        var fq = GetPassengerQueue(floor);
+        var toBoard = new List<Passenger>();
+
+        // Decide which direction to load:
+        // - If elevator is moving, load that direction (keeps service efficient)
+        // - If idle, choose the heavier queue; if both empty, nothing to do
+        Direction dirToLoad = elevator.Direction;
+        if (dirToLoad == Direction.Idle)
+        {
+            if (fq.Up.Count == 0 && fq.Down.Count == 0)
+            {
+                _events.Add($"Stop F:{floor} | Unloaded:{unloaded} Boarded:0 RemainingUp:{fq.Up.Count} RemainingDown:{fq.Down.Count}");
+                return;
+            }
+            dirToLoad = fq.Up.Count >= fq.Down.Count ? Direction.Up : Direction.Down;
+        }
+
+        while (elevator.AvailableCapacity > 0)
+        {
+            var p = fq.TryDequeue(dirToLoad);
+            if (p == null)
+            {
+                // If idle at open time and chosen dir is empty, try the other direction once
+                if (elevator.Direction == Direction.Idle)
+                {
+                    var altDir = dirToLoad == Direction.Up ? Direction.Down : Direction.Up;
+                    p = fq.TryDequeue(altDir);
+                }
+
+                if (p == null) break; // nothing to board
+            }
+            toBoard.Add(p);
+        }
+
+        int boarded = elevator.BoardPassengers(toBoard);
+
+        _events.Add($"Stop F:{floor} | Unloaded:{unloaded} Boarded:{boarded} RemainingUp:{fq.Up.Count} RemainingDown:{fq.Down.Count}");
+    }
+
+    public void OnDoorsClosed(IElevator elevator, int floor)
+    {
+        // After close, try re-dispatch in case there are still passengers waiting
+        TryDispatchQueues();
+    }
+
+    // Internal helpers
+
+    private void TryDispatchQueues()
+    {
+        foreach (var kv in _passengerQueues)
+        {
+            int floor = kv.Key;
+            var fq = kv.Value;
+
+            // Try dispatch both directions that have waiting passengers
+            if (fq.Up.Count > 0)
+                TryDispatchFloorDirection(floor, Direction.Up, fq.Up.Count);
+
+            if (fq.Down.Count > 0)
+                TryDispatchFloorDirection(floor, Direction.Down, fq.Down.Count);
+        }
+    }
+
+    private void TryDispatchFloorDirection(int floor, Direction dir, int count)
+    {
+        var req = new Request(floor, dir, count);
+        var chosen = DispatchStrategy.ChooseElevator(this, req);
+        if (chosen != null && chosen.CanAccept(req))
+        {
+            chosen.Assign(req);
+            // We do not dequeue passengers here—boarding happens on door open.
+            // If you want to sync the legacy request queue for visibility, you can clear matching entries:
+            // ClearMatchingRequests(floor, dir);
+        }
+    }
+
+    private FloorQueue GetPassengerQueue(int floor)
+    {
+        if (!_passengerQueues.TryGetValue(floor, out var fq))
+        {
+            fq = new FloorQueue(floor);
+            _passengerQueues[floor] = fq;
+        }
+        return fq;
     }
 
     private void ValidateFloor(int floor)
     {
         if (floor < 0 || floor >= Floors)
             throw new ArgumentOutOfRangeException(nameof(floor), $"Floor must be in [0..{Floors - 1}]");
+    }
+
+    // Optional: keep legacy _floorRequestQueues roughly in sync (not required for Day 3)
+    private void ClearMatchingRequests(int floor, Direction dir)
+    {
+        if (!_floorRequestQueues.TryGetValue(floor, out var q)) return;
+        var remaining = new Queue<Request>();
+        while (q.Count > 0)
+        {
+            var r = q.Dequeue();
+            if (r.Direction != dir) remaining.Enqueue(r);
+        }
+        _floorRequestQueues[floor] = remaining;
     }
 }

--- a/src/ElevatorSim.Domain/FloorQueue.cs
+++ b/src/ElevatorSim.Domain/FloorQueue.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace ElevatorSim.Domain;
+
+public sealed class FloorQueue
+{
+    public int Floor { get; }
+    // Separate queues by direction
+    public Queue<Passenger> Up { get; } = new();
+    public Queue<Passenger> Down { get; } = new();
+
+    public FloorQueue(int floor) => Floor = floor;
+
+    public int Count(Direction dir) => dir == Direction.Up ? Up.Count : Down.Count;
+
+    public void Enqueue(Direction dir, Passenger p)
+    {
+        if (dir == Direction.Up) Up.Enqueue(p);
+        else Down.Enqueue(p);
+    }
+
+    public Passenger? TryDequeue(Direction dir)
+    {
+        if (dir == Direction.Up && Up.Count > 0) return Up.Dequeue();
+        if (dir == Direction.Down && Down.Count > 0) return Down.Dequeue();
+        return null;
+    }
+}

--- a/src/ElevatorSim.Domain/IElevator.cs
+++ b/src/ElevatorSim.Domain/IElevator.cs
@@ -11,10 +11,19 @@ public interface IElevator
     int PassengerCount { get; }
     IReadOnlyList<int> Targets { get; }
     ElevatorState State { get; } // To expose State from ElevatorBase via IElevator
+    IReadOnlyList<Passenger> Passengers { get; }
+    int AvailableCapacity { get; }
 
     bool CanAccept(Request req);
     void Assign(Request req);
     void Tick();
+
+    // Day 3: operations needed by Building without referencing Infrastructure
+    int UnloadAtCurrentFloor();
+    int BoardPassengers(IEnumerable<Passenger> boarding);
+
+    // Day 3: observer hook
+    IElevatorObserver? Observer { get; set; }
 }
 
 public interface IDispatchStrategy

--- a/src/ElevatorSim.Domain/IElevatorObserver.cs
+++ b/src/ElevatorSim.Domain/IElevatorObserver.cs
@@ -1,0 +1,8 @@
+﻿using ElevatorSim.Domain;
+
+public interface IElevatorObserver
+{
+    void OnArrivedAtFloor(IElevator elevator, int floor);
+    void OnDoorsOpened(IElevator elevator, int floor);
+    void OnDoorsClosed(IElevator elevator, int floor);
+}

--- a/src/ElevatorSim.Domain/Passenger.cs
+++ b/src/ElevatorSim.Domain/Passenger.cs
@@ -1,0 +1,16 @@
+﻿namespace ElevatorSim.Domain;
+
+public sealed class Passenger
+{
+    public int OriginFloor { get; }
+    public int DestinationFloor { get; }
+    public Direction Direction => DestinationFloor > OriginFloor ? Direction.Up
+                               : DestinationFloor < OriginFloor ? Direction.Down
+                               : Direction.Idle;
+
+    public Passenger(int originFloor, int destinationFloor)
+    {
+        OriginFloor = originFloor;
+        DestinationFloor = destinationFloor;
+    }
+}

--- a/src/ElevatorSim.Domain/Requests.cs
+++ b/src/ElevatorSim.Domain/Requests.cs
@@ -4,18 +4,18 @@ public sealed class Request
 {
     public int Floor { get; }
     public Direction Direction { get; }
-    public int People { get; set; }
+    public int Count { get; }
 
-    public Request(int floor, Direction direction, int people)
+    public Request(int floor, Direction direction, int count)
     {
         if (!Enum.IsDefined(typeof(Direction), direction) || direction == Direction.Idle)
             throw new ArgumentException("Direction must be Up or Down.", nameof(direction));
-        if (people <= 0) throw new ArgumentOutOfRangeException(nameof(people), "People must be > 0.");
+        if (count <= 0) throw new ArgumentOutOfRangeException(nameof(count), "People must be > 0.");
 
         Floor = floor;
         Direction = direction;
-        People = people;
+        Count = count;
     }
 
-    public override string ToString() => $"Req(F:{Floor}, Dir:{Direction}, P:{People})";
+    public override string ToString() => $"Req(F:{Floor}, Dir:{Direction}, P:{Count})";
 }

--- a/tests/ElevatorSim.Tests/CapacityAndQueuesTests.cs
+++ b/tests/ElevatorSim.Tests/CapacityAndQueuesTests.cs
@@ -1,0 +1,33 @@
+﻿using ElevatorSim.Domain;
+using ElevatorSim.Infrastructure.Dispatch;
+using ElevatorSim.Infrastructure.Elevators;
+using Xunit;
+using System.Collections.Generic;
+
+public class CapacityAndQueuesTests
+{
+    [Fact]
+    public void LoadsUpToCapacityAndLeavesRemainderQueued()
+    {
+        var e1 = new PassengerElevator("E1", startFloor: 0, capacity: 4, speedTicksPerFloor: 1, doorOpenTicks: 1, doorCloseTicks: 1);
+        var building = new Building(12, new NearestAvailableDispatch());
+        building.AddElevator(e1);
+
+        // Submit 6 passengers waiting at floor 0, going up
+        var req = new Request(0, Direction.Up, 6);
+        building.SubmitCall(req);
+
+        // Force the elevator to serve floor 0 now (bypass strategy variability)
+        e1.Assign(req);
+
+        // Act: tick until doors open and loading occurs
+        // One tick to transition DoorsClosed -> DoorsOpening (if needed),
+        // another to DoorsOpen (doorOpenTicks = 1), then Building.OnDoorsOpened loads.
+        for (int i = 0; i < 3; i++)
+        {
+            building.TickAll();
+        }
+
+        Assert.Equal(4, e1.Passengers.Count);
+    }
+}


### PR DESCRIPTION
## Description
- Extend `IElevator` to expose:
  - `Passengers`, `AvailableCapacity`
  - `UnloadAtCurrentFloor()`, `BoardPassengers(IEnumerable<Passenger>)`
  - `IElevatorObserver? Observer` hook
- Implement observer pattern:
  - `Building` listens to elevator events
  - On `DoorsOpened`: unload first, then board up to capacity
- Add per-floor `FloorQueue` (Up/Down) and re-dispatch remaining passengers after ticks
- Stabilize door cycle in `ElevatorBase` (proper tick budgeting; prevent `DoorsOpening` re-entry loop)
- Align `Request` count (`People`/`Count` alias) and ensure `SubmitCall` enqueues the correct number of passengers
- Console functional testing validated:
  - `call 0 up 6` → boards 6 and creates internal targets
  - `call 0 up 20` → boards 10, unloads at destination, overflow remains queued

## Notes
- Preserves Clean Architecture (Domain independent of Infrastructure)
- No changes required to console commands; event messages show unload/board counts

## Checklist
- [x] Capacity respected; overflow remains queued
- [x] Passengers unloaded at destination floors
- [x] `DoorsOpening → DoorsOpen → DoorsClosing` stabilized
- [x] `Request` count unified
- [x] Smoke-tested via console (`status` / `call` / `tick` / `auto`)