### PR TITLE
Day 7: Wait-time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,22 @@ Auto-tick: ON (300ms)
 - tick 25 → advances 25 ticks and prints a summary.
 - events 10 → shows arrivals, stops, and OOS toggles.
 
+### Day 7 — Wait-time metrics
+
+#### What’s new
+- Wait-time metrics tracked from call to boarding.
+- `metrics` console command to display served count, average wait, and max wait (ticks).
+
+#### Commands
+- metrics
+
+#### Manual verification
+- `call 0 up 12`
+- `auto on` (let the first car board 10)
+- `auto off`
+- `metrics` → should show `Served: 10` and non-zero avg/max wait
+- Turn auto back on to board the remaining passengers; `metrics` will update (e.g., `Served: 12`)
+
 #### Build/Run requirements
 - Windows 11 (dev environment)
 - .NET 8 SDK

--- a/src/ElevatorSim.Console/Program.cs
+++ b/src/ElevatorSim.Console/Program.cs
@@ -90,7 +90,15 @@ public static class Program
                         Console.WriteLine("  auto on|off");
                         Console.WriteLine("  oos <elevatorId> <on|off>");
                         Console.WriteLine("  events [N]");
+                        Console.WriteLine("  metrics");
                         Console.WriteLine("  quit");
+                        break;
+                    }
+
+                case "metrics":
+                    {
+                        var (served, avg, max) = building.GetWaitMetrics();
+                        Console.WriteLine($"Served: {served} | Avg wait ticks: {avg:F2} | Max wait ticks: {max}");
                         break;
                     }
 


### PR DESCRIPTION
### Summary
- Track wait times per passenger (from enqueue to boarding) using created tick stamps.
- Accumulate average and maximum wait times.
- Add `metrics` console command to display `Served`, `Avg wait ticks`, and `Max wait ticks`.
- Advance simulation tick in `TickAll()`.

### How to verify
```text
call 0 up 12
auto on         # first car boards 10
auto off
metrics         # expect Served: 10, avg/max > 0
auto on         # board remaining
auto off
metrics         # expect Served: 12 with updated averages